### PR TITLE
Fix !pivot, !recovery, !zrecovery, !priority in dexsearch

### DIFF
--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -746,6 +746,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 					const invalid = validParameter("moves", move, isNotSearch, target);
 					if (invalid) return {error: invalid};
 					if (isNotSearch) {
+						orGroup.skip = true;
 						const bufferObj: {moves: {[k: string]: boolean}} = {moves: {}};
 						bufferObj.moves[move] = false;
 						searches.push(bufferObj as DexOrGroup);
@@ -765,6 +766,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 					const invalid = validParameter("moves", moveid, isNotSearch, target);
 					if (invalid) return {error: invalid};
 					if (isNotSearch) {
+						orGroup.skip = true;
 						const bufferObj: {moves: {[k: string]: boolean}} = {moves: {}};
 						bufferObj.moves[moveid] = false;
 						searches.push(bufferObj as DexOrGroup);
@@ -783,6 +785,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 						const invalid = validParameter("moves", moveid, isNotSearch, target);
 						if (invalid) return {error: invalid};
 						if (isNotSearch) {
+							orGroup.skip = true;
 							const bufferObj: {moves: {[k: string]: boolean}} = {moves: {}};
 							bufferObj.moves[moveid] = false;
 							searches.push(bufferObj as DexOrGroup);
@@ -849,6 +852,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 						const invalid = validParameter("moves", move, isNotSearch, target);
 						if (invalid) return {error: invalid};
 						if (isNotSearch) {
+							orGroup.skip = true;
 							const bufferObj: {moves: {[k: string]: boolean}} = {moves: {}};
 							bufferObj.moves[move] = false;
 							searches.push(bufferObj as DexOrGroup);


### PR DESCRIPTION
Currently, running any of `/nds !pivot`, `/nds !recovery`, `/nds !zrecovery`, and `/nds !priority` results in "No Pokémon found.". This is because they are adding an empty DexOrGroup
```js
  {
    abilities: {},
    tiers: {},
    doublesTiers: {},
    colors: {},
    'egg groups': {},
    formes: {},
    gens: {},
    moves: {},
    types: {},
    resists: {},
    weak: {},
    stats: {},
    skip: false
  }
```
to `searches`, which naturally no Pokémon can satisfy and therefore eliminates all possibilities. This change sets `skip` to `true` for these empty DexOrGroups so that they will be ignored when finding possibilities.